### PR TITLE
Skip startup typeset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export default class extends Component {
       MathJax.Hub.Config(Object.assign({
         showMathMenu: true,
         tex2jax: { inlineMath: [['$','$'],['\\(','\\)']] },
+        skipStartupTypeset: true,
       }, this.props.config))
       window.MathJax.Hub.Queue(['Typeset', window.MathJax.Hub, this.preview])
     }


### PR DESCRIPTION
Normally MathJax will typeset the mathematics on the page as soon as the page is loaded. 
That means all the strings in the document that starts and ends with $$ will be rendred to mathjax-preview. 
I think the `skipStartupTypeset` parameter should be configured to `true` since this package call MathJax.Hub.Typeset() manually.

Docs : https://docs.mathjax.org/en/v2.7-latest/options/hub.html?highlight=skipstartuptypeset