### PR TITLE
prevent flickering

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import DOMPurify from "dompurify";
-import { Transition } from "react-transition-group";
 
 const baseConfig = {
   showMathMenu: true,
@@ -74,7 +73,7 @@ const MathJaxPreview = ({
 
     //delay display of div
     var msDelay;
-    if (
+    if ( //msDelayDisplay prop is a reasonable number of ms
       msDelayDisplay &&
       !isNaN(+msDelayDisplay) &&
       +msDelayDisplay >= 0 &&
@@ -82,11 +81,11 @@ const MathJaxPreview = ({
     ) {
       msDelay = +msDelayDisplay;
     } else {
-      msDelay = 300;
+      msDelay = 300; // default 300ms delay
     }
     setTimeout(() => {
-      setDisplay("inline");
-    }, msDelay); //svgpubs@github hopes to prevent render flicker
+      setDisplay("inline"); //display div after delay, hopefully typeset has finished
+    }, msDelay); 
     return () => {
       setDisplay("none");
     };

--- a/index.jsx
+++ b/index.jsx
@@ -74,7 +74,7 @@ const MathJaxPreview = ({
     //delay display of div
     var msDelay;
     if ( //msDelayDisplay prop is a reasonable number of ms
-      msDelayDisplay == null &&
+      msDelayDisplay !== null &&
       !isNaN(+msDelayDisplay) &&
       +msDelayDisplay >= 0 &&
       +msDelayDisplay < 10000

--- a/index.jsx
+++ b/index.jsx
@@ -20,7 +20,7 @@ const MathJaxPreview = ({
   math,
   id,
   style,
-  msDelayDisplay,
+  msDelayDisplay, //milliseconds to delay display of div, 300 is default
 }) => {
   const sanitizedMath = DOMPurify.sanitize(math);
   const previewRef = useRef();

--- a/index.jsx
+++ b/index.jsx
@@ -74,7 +74,7 @@ const MathJaxPreview = ({
     //delay display of div
     var msDelay;
     if ( //msDelayDisplay prop is a reasonable number of ms
-      msDelayDisplay &&
+      msDelayDisplay == null &&
       !isNaN(+msDelayDisplay) &&
       +msDelayDisplay >= 0 &&
       +msDelayDisplay < 10000

--- a/index.jsx
+++ b/index.jsx
@@ -1,73 +1,81 @@
-import React, { useEffect, useState, useRef } from 'react'
-import PropTypes from 'prop-types'
-import DOMPurify from 'dompurify'
+import React, { useEffect, useState, useRef } from "react";
+import PropTypes from "prop-types";
+import DOMPurify from "dompurify";
 
 const baseConfig = {
   showMathMenu: true,
   tex2jax: {
     inlineMath: [
-      ['$', '$'],
-      ['\\(', '\\)']
-    ]
+      ["$", "$"],
+      ["\\(", "\\)"],
+    ],
   },
-  skipStartupTypeset: true
-}
+  skipStartupTypeset: true,
+};
 
 const MathJaxPreview = ({ script, config, className, math, style, id }) => {
-  const sanitizedMath = DOMPurify.sanitize(math)
-  const previewRef = useRef()
-  const [loadingState, setLoadingState] = useState(window.MathJax ? 'loaded' : 'loading')
+  const sanitizedMath = DOMPurify.sanitize(math);
+  const previewRef = useRef();
+  const [visibility, setVisibility] = useState("hidden"); //svgpubs@github hopes to prevent render flicker
+  const [loadingState, setLoadingState] = useState(
+    window.MathJax ? "loaded" : "loading"
+  );
 
   useEffect(() => {
-    let mathjaxScriptTag = document.querySelector(
-      `script[src="${script}"]`
-    )
+    let mathjaxScriptTag = document.querySelector(`script[src="${script}"]`);
     if (!mathjaxScriptTag) {
-      mathjaxScriptTag = document.createElement('script')
-      mathjaxScriptTag.async = true
-      mathjaxScriptTag.src = script
+      mathjaxScriptTag = document.createElement("script");
+      mathjaxScriptTag.async = true;
+      mathjaxScriptTag.src = script;
 
       for (const [k, v] of Object.entries(config || {})) {
-        mathjaxScriptTag.setAttribute(k, v)
+        mathjaxScriptTag.setAttribute(k, v);
       }
-      const node = document.head || document.getElementsByTagName('head')[0]
-      node.appendChild(mathjaxScriptTag)
+      const node = document.head || document.getElementsByTagName("head")[0];
+      node.appendChild(mathjaxScriptTag);
     }
     const onloadHandler = () => {
-      setLoadingState('loaded')
-      window.MathJax.Hub.Config({ ...baseConfig, ...config })
-    }
+      setLoadingState("loaded");
+      window.MathJax.Hub.Config({ ...baseConfig, ...config });
+    };
     const onerrorHandler = () => {
-      setLoadingState('failed')
-    }
+      setLoadingState("failed");
+    };
 
-    mathjaxScriptTag.addEventListener('load', onloadHandler)
-    mathjaxScriptTag.addEventListener('error', onerrorHandler)
+    mathjaxScriptTag.addEventListener("load", onloadHandler);
+    mathjaxScriptTag.addEventListener("error", onerrorHandler);
 
     return () => {
-      mathjaxScriptTag.removeEventListener('load', onloadHandler)
-      mathjaxScriptTag.removeEventListener('error', onloadHandler)
-    }
-  }, [setLoadingState, config, baseConfig])
+      mathjaxScriptTag.removeEventListener("load", onloadHandler);
+      mathjaxScriptTag.removeEventListener("error", onloadHandler);
+    };
+  }, [setLoadingState, config, baseConfig]);
 
   useEffect(() => {
-    if (loadingState !== 'loaded') {
-      return
+    if (loadingState !== "loaded") {
+      return;
     }
-    previewRef.current.innerHTML = sanitizedMath
+    previewRef.current.innerHTML = sanitizedMath;
     window.MathJax.Hub.Queue([
-      'Typeset',
+      "Typeset",
       window.MathJax.Hub,
-      previewRef.current
-    ])
-  }, [sanitizedMath, loadingState, previewRef])
+      previewRef.current,
+    ]);
+    setTimeout(() => {
+      setVisibility("visible");
+    }, 300); //svgpubs@github hopes to prevent render flicker
+  }, [sanitizedMath, loadingState, previewRef]);
   return (
     <div className={className} id={id} style={style}>
-      {loadingState === 'failed' && <span>fail loading mathjax lib</span>}
-      <div className='react-mathjax-preview-result' ref={previewRef} />
+      {loadingState === "failed" && <span>fail loading mathjax lib</span>}
+      <div
+        className="react-mathjax-preview-result"
+        ref={previewRef}
+        style={{ visibility: visibility }} // hide for some time until it is probalby done
+      />
     </div>
-  )
-}
+  );
+};
 
 MathJaxPreview.propTypes = {
   script: PropTypes.string,
@@ -75,12 +83,13 @@ MathJaxPreview.propTypes = {
   className: PropTypes.string,
   math: PropTypes.string,
   style: PropTypes.object,
-  id: PropTypes.string
-}
+  id: PropTypes.string,
+};
 
 MathJaxPreview.defaultProps = {
-  script: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_HTMLorMML',
-  id: 'react-mathjax-preview'
-}
+  script:
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_HTMLorMML",
+  id: "react-mathjax-preview",
+};
 
-export default MathJaxPreview
+export default MathJaxPreview;


### PR DESCRIPTION
by allowing the user to set a delay for rendering, the math processing does not flicker the screen. 

previous 
```
<MJ2 math={equation.latex} />
```

new
```
<MJ2 math={equation.latex} msDelayDisplay={300} />
```